### PR TITLE
Squash BT commits to fix build

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -85,8 +85,10 @@ LOCAL_SRC_FILES += \
 	core/java/android/app/backup/IRestoreObserver.aidl \
 	core/java/android/app/backup/IRestoreSession.aidl \
 	core/java/android/bluetooth/IBluetooth.aidl \
+	core/java/android/bluetooth/IQBluetooth.aidl \
 	core/java/android/bluetooth/IBluetoothA2dp.aidl \
 	core/java/android/bluetooth/IBluetoothCallback.aidl \
+	core/java/android/bluetooth/IQBluetoothAdapterCallback.aidl \
 	core/java/android/bluetooth/IBluetoothHeadset.aidl \
 	core/java/android/bluetooth/IBluetoothHeadsetPhone.aidl \
 	core/java/android/bluetooth/IBluetoothHealth.aidl \
@@ -95,10 +97,13 @@ LOCAL_SRC_FILES += \
 	core/java/android/bluetooth/IBluetoothPan.aidl \
 	core/java/android/bluetooth/IBluetoothManager.aidl \
 	core/java/android/bluetooth/IBluetoothManagerCallback.aidl \
+	core/java/android/bluetooth/IQBluetoothManagerCallback.aidl \
 	core/java/android/bluetooth/IBluetoothPbap.aidl \
 	core/java/android/bluetooth/IBluetoothMap.aidl \
 	core/java/android/bluetooth/IBluetoothStateChangeCallback.aidl \
 	core/java/android/bluetooth/IBluetoothHandsfreeClient.aidl \
+	core/java/android/bluetooth/IBluetoothHidDevice.aidl \
+	core/java/android/bluetooth/IBluetoothHidDeviceCallback.aidl \
 	core/java/android/bluetooth/IBluetoothGatt.aidl \
 	core/java/android/bluetooth/IBluetoothGattCallback.aidl \
 	core/java/android/bluetooth/IBluetoothGattServerCallback.aidl \
@@ -396,6 +401,7 @@ aidl_files := \
 	frameworks/base/core/java/com/android/internal/view/IInputMethodClient.aidl \
 	frameworks/base/core/java/com/android/internal/view/IInputMethodManager.aidl \
 	frameworks/base/core/java/com/android/internal/view/IInputMethodSession.aidl \
+        frameworks/base/core/java/android/bluetooth/BluetoothLEServiceUuid.aidl  \
 	frameworks/base/graphics/java/android/graphics/Bitmap.aidl \
 	frameworks/base/graphics/java/android/graphics/Rect.aidl \
 	frameworks/base/graphics/java/android/graphics/Region.aidl \

--- a/core/java/android/bluetooth/BluetoothAdapter.java
+++ b/core/java/android/bluetooth/BluetoothAdapter.java
@@ -1214,6 +1214,9 @@ public final class BluetoothAdapter {
         } else if (profile == BluetoothProfile.HANDSFREE_CLIENT) {
             BluetoothHandsfreeClient hfpclient = new BluetoothHandsfreeClient(context, listener);
             return true;
+        } else if (profile == BluetoothProfile.HID_DEVICE) {
+            BluetoothHidDevice hidd = new BluetoothHidDevice(context, listener);
+            return true;
         } else {
             return false;
         }
@@ -1277,6 +1280,10 @@ public final class BluetoothAdapter {
             case BluetoothProfile.HANDSFREE_CLIENT:
                 BluetoothHandsfreeClient hfpclient = (BluetoothHandsfreeClient)proxy;
                 hfpclient.close();
+                break;
+            case BluetoothProfile.HID_DEVICE:
+                BluetoothHidDevice hidd = (BluetoothHidDevice) proxy;
+                hidd.close();
                 break;
         }
     }

--- a/core/java/android/bluetooth/BluetoothHidDevice.java
+++ b/core/java/android/bluetooth/BluetoothHidDevice.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @hide
+ */
+public final class BluetoothHidDevice implements BluetoothProfile {
+
+    private static final String TAG = BluetoothHidDevice.class.getSimpleName();
+
+    public static final String ACTION_CONNECTION_STATE_CHANGED =
+        "android.bluetooth.hid.profile.action.CONNECTION_STATE_CHANGED";
+
+    /**
+     * Constants representing device subclass.
+     *
+     * @see #registerApp(String, String, String, byte, byte[],
+     *      BluetoothHidDeviceCallback)
+     */
+    public static final byte SUBCLASS1_NONE = (byte) 0x00;
+    public static final byte SUBCLASS1_KEYBOARD = (byte) 0x40;
+    public static final byte SUBCLASS1_MOUSE = (byte) 0x80;
+    public static final byte SUBCLASS1_COMBO = (byte) 0xC0;
+
+    public static final byte SUBCLASS2_UNCATEGORIZED = (byte) 0x00;
+    public static final byte SUBCLASS2_JOYSTICK = (byte) 0x01;
+    public static final byte SUBCLASS2_GAMEPAD = (byte) 0x02;
+    public static final byte SUBCLASS2_REMOTE_CONTROL = (byte) 0x03;
+    public static final byte SUBCLASS2_SENSING_DEVICE = (byte) 0x04;
+    public static final byte SUBCLASS2_DIGITIZER_TABLED = (byte) 0x05;
+    public static final byte SUBCLASS2_CARD_READER = (byte) 0x06;
+
+    /**
+     * Constants representing report types.
+     *
+     * @see BluetoothHidDeviceCallback#onGetReport(byte, byte, int)
+     * @see BluetoothHidDeviceCallback#onSetReport(byte, byte, byte[])
+     * @see BluetoothHidDeviceCallback#onIntrData(byte, byte[])
+     */
+    public static final byte REPORT_TYPE_INPUT = (byte) 1;
+    public static final byte REPORT_TYPE_OUTPUT = (byte) 2;
+    public static final byte REPORT_TYPE_FEATURE = (byte) 3;
+
+    /**
+     * Constants representing protocol mode used set by host. Default is always
+     * {@link #PROTOCOL_REPORT_MODE} unless notified otherwise.
+     *
+     * @see BluetoothHidDeviceCallback#onSetProtocol(byte)
+     */
+    public static final byte PROTOCOL_BOOT_MODE = (byte) 0;
+    public static final byte PROTOCOL_REPORT_MODE = (byte) 1;
+
+    private Context mContext;
+
+    private ServiceListener mServiceListener;
+
+    private IBluetoothHidDevice mService;
+
+    private BluetoothAdapter mAdapter;
+
+    private static class BluetoothHidDeviceCallbackWrapper extends IBluetoothHidDeviceCallback.Stub {
+
+        private BluetoothHidDeviceCallback mCallback;
+
+        public BluetoothHidDeviceCallbackWrapper(BluetoothHidDeviceCallback callback) {
+            mCallback = callback;
+        }
+
+        @Override
+        public void onAppStatusChanged(BluetoothDevice pluggedDevice,
+                BluetoothHidDeviceAppConfiguration config, boolean registered) {
+            mCallback.onAppStatusChanged(pluggedDevice, config, registered);
+        }
+
+        @Override
+        public void onConnectionStateChanged(BluetoothDevice device, int state) {
+            mCallback.onConnectionStateChanged(device, state);
+        }
+
+        @Override
+        public void onGetReport(byte type, byte id, int bufferSize) {
+            mCallback.onGetReport(type, id, bufferSize);
+        }
+
+        @Override
+        public void onSetReport(byte type, byte id, byte[] data) {
+            mCallback.onSetReport(type, id, data);
+        }
+
+        @Override
+        public void onSetProtocol(byte protocol) {
+            mCallback.onSetProtocol(protocol);
+        }
+
+        @Override
+        public void onIntrData(byte reportId, byte[] data) {
+            mCallback.onIntrData(reportId, data);
+        }
+
+        @Override
+        public void onVirtualCableUnplug() {
+            mCallback.onVirtualCableUnplug();
+        }
+    }
+
+    final private IBluetoothStateChangeCallback mBluetoothStateChangeCallback =
+        new IBluetoothStateChangeCallback.Stub() {
+
+        public void onBluetoothStateChange(boolean up) {
+            Log.d(TAG, "onBluetoothStateChange: up=" + up);
+
+            synchronized (mConnection) {
+                if (!up) {
+                    mService = null;
+                    mContext.unbindService(mConnection);
+                } else {
+                    if (mService == null) {
+                        Log.v(TAG, "Binding service");
+                        if (!mContext.bindService(new Intent(IBluetoothHidDevice.class.getName()),
+                            mConnection, 0)) {
+                            Log.e(TAG, "Could not bind service");
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    private ServiceConnection mConnection = new ServiceConnection() {
+
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            Log.d(TAG, "onServiceConnected()");
+
+            mService = IBluetoothHidDevice.Stub.asInterface(service);
+
+            if (mServiceListener != null) {
+                mServiceListener.onServiceConnected(BluetoothProfile.HID_DEVICE,
+                    BluetoothHidDevice.this);
+            }
+        }
+
+        public void onServiceDisconnected(ComponentName className) {
+            Log.d(TAG, "onServiceDisconnected()");
+
+            mService = null;
+
+            if (mServiceListener != null) {
+                mServiceListener.onServiceDisconnected(BluetoothProfile.HID_DEVICE);
+            }
+        }
+    };
+
+    BluetoothHidDevice(Context context, ServiceListener listener) {
+        Log.v(TAG, "BluetoothInputDevice()");
+
+        mContext = context;
+        mServiceListener = listener;
+        mAdapter = BluetoothAdapter.getDefaultAdapter();
+
+        IBluetoothManager mgr = mAdapter.getBluetoothManager();
+        if (mgr != null) {
+            try {
+                mgr.registerStateChangeCallback(mBluetoothStateChangeCallback);
+            } catch (RemoteException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (!context.bindService(new Intent(IBluetoothHidDevice.class.getName()),
+            mConnection, 0)) {
+            Log.e(TAG, "Could not bind service");
+        }
+    }
+
+    void close() {
+        Log.v(TAG, "close()");
+
+        IBluetoothManager mgr = mAdapter.getBluetoothManager();
+        if (mgr != null) {
+            try {
+                mgr.unregisterStateChangeCallback(mBluetoothStateChangeCallback);
+            } catch (RemoteException e) {
+                e.printStackTrace();
+            }
+        }
+
+        synchronized (mConnection) {
+            if (mService != null) {
+                mService = null;
+                mContext.unbindService(mConnection);
+           }
+        }
+
+        mServiceListener = null;
+    }
+
+    @Override
+    public List<BluetoothDevice> getConnectedDevices() {
+        Log.v(TAG, "getConnectedDevices()");
+        return null;
+    }
+
+    @Override
+    public List<BluetoothDevice> getDevicesMatchingConnectionStates(int[] states) {
+        Log.v(TAG, "getDevicesMatchingConnectionStates(): states=" + Arrays.toString(states));
+        return null;
+    }
+
+    @Override
+    public int getConnectionState(BluetoothDevice device) {
+        Log.v(TAG, "getConnectionState(): device=" + device.getAddress());
+
+        return STATE_DISCONNECTED;
+    }
+
+    /**
+     * Registers application to be used for HID device. Connections to HID
+     * Device are only possible when application is registered. Only one
+     * application can be registered at time. When no longer used, application
+     * should be unregistered using
+     * {@link #unregisterApp(BluetoothHidDeviceAppConfiguration)}.
+     *
+     * @param sdp {@link BluetoothHidDeviceAppSdpSettings} object of
+     *             HID Device SDP record.
+     * @param inQos {@link BluetoothHidDeviceAppQosSettings} object of
+     *             Incoming QoS Settings.
+     * @param outQos {@link BluetoothHidDeviceAppQosSettings} object of
+     *             Outgoing QoS Settings.
+     * @param callback {@link BluetoothHidDeviceCallback} object to which
+     *            callback messages will be sent.
+     * @return
+     */
+    public boolean registerApp(BluetoothHidDeviceAppSdpSettings sdp,
+            BluetoothHidDeviceAppQosSettings inQos, BluetoothHidDeviceAppQosSettings outQos,
+            BluetoothHidDeviceCallback callback) {
+        Log.v(TAG, "registerApp(): sdp=" + sdp + " inQos=" + inQos + " outQos=" + outQos
+                + " callback=" + callback);
+
+        boolean result = false;
+
+        if (sdp == null || callback == null) {
+            return false;
+        }
+
+        if (mService != null) {
+            try {
+                BluetoothHidDeviceAppConfiguration config =
+                    new BluetoothHidDeviceAppConfiguration();
+                BluetoothHidDeviceCallbackWrapper cbw =
+                    new BluetoothHidDeviceCallbackWrapper(callback);
+                result = mService.registerApp(config, sdp, inQos, outQos, cbw);
+            } catch (RemoteException e) {
+                Log.e(TAG, e.toString());
+            }
+        } else {
+            Log.w(TAG, "Proxy not attached to service");
+        }
+
+        return result;
+    }
+
+    /**
+     * Unregisters application. Active connection will be disconnected and no
+     * new connections will be allowed until registered again using
+     * {@link #registerApp(String, String, String, byte, byte[], BluetoothHidDeviceCallback)}
+     *
+     * @param config {@link BluetoothHidDeviceAppConfiguration} object as
+     *            obtained from
+     *            {@link BluetoothHidDeviceCallback#onAppStatusChanged(BluetoothDevice,
+     *            BluetoothHidDeviceAppConfiguration, boolean)}
+     *
+     * @return
+     */
+    public boolean unregisterApp(BluetoothHidDeviceAppConfiguration config) {
+        Log.v(TAG, "unregisterApp()");
+
+        boolean result = false;
+
+        if (mService != null) {
+            try {
+                result = mService.unregisterApp(config);
+            } catch (RemoteException e) {
+                Log.e(TAG, e.toString());
+            }
+        } else {
+            Log.w(TAG, "Proxy not attached to service");
+        }
+
+        return result;
+    }
+
+    /**
+     * Sends report to remote host using interrupt channel.
+     *
+     * @param id Report Id, as defined in descriptor. Can be 0 in case Report Id
+     *            are not defined in descriptor.
+     * @param data Report data, not including Report Id.
+     * @return
+     */
+    public boolean sendReport(int id, byte[] data) {
+        Log.v(TAG, "sendReport(): id=" + id);
+
+        boolean result = false;
+
+        if (mService != null) {
+            try {
+                result = mService.sendReport(id, data);
+            } catch (RemoteException e) {
+                Log.e(TAG, e.toString());
+            }
+        } else {
+            Log.w(TAG, "Proxy not attached to service");
+        }
+
+        return result;
+    }
+
+    /**
+     * Sends report to remote host as reply for GET_REPORT request from
+     * {@link BluetoothHidDeviceCallback#onGetReport(byte, byte, int)}.
+     *
+     * @param type Report Type, as in request.
+     * @param id Report Id, as in request.
+     * @param data Report data, not including Report Id.
+     * @return
+     */
+    public boolean replyReport(byte type, byte id, byte[] data) {
+        Log.v(TAG, "replyReport(): type=" + type + " id=" + id);
+
+        boolean result = false;
+
+        if (mService != null) {
+            try {
+                result = mService.replyReport(type, id, data);
+            } catch (RemoteException e) {
+                Log.e(TAG, e.toString());
+            }
+        } else {
+            Log.w(TAG, "Proxy not attached to service");
+        }
+
+        return result;
+    }
+
+    /**
+     * Sends error handshake message as reply for invalid SET_REPORT request
+     * from {@link BluetoothHidDeviceCallback#onSetReport(byte, byte, byte[])}.
+     *
+     * @return
+     */
+    public boolean reportError() {
+        Log.v(TAG, "reportError()");
+
+        boolean result = false;
+
+        if (mService != null) {
+            try {
+                result = mService.reportError();
+            } catch (RemoteException e) {
+                Log.e(TAG, e.toString());
+            }
+        } else {
+            Log.w(TAG, "Proxy not attached to service");
+        }
+
+        return result;
+    }
+
+    /**
+     * Sends Virtual Cable Unplug to currently connected host.
+     *
+     * @return
+     */
+    public boolean unplug() {
+        Log.v(TAG, "unplug()");
+
+        boolean result = false;
+
+        if (mService != null) {
+            try {
+                result = mService.unplug();
+            } catch (RemoteException e) {
+                Log.e(TAG, e.toString());
+            }
+        } else {
+            Log.w(TAG, "Proxy not attached to service");
+        }
+
+        return result;
+    }
+
+    /**
+     * Initiates connection to host which currently has Virtual Cable
+     * established with device.
+     *
+     * @return
+     */
+    public boolean connect() {
+        Log.v(TAG, "connect()");
+
+        boolean result = false;
+
+        if (mService != null) {
+            try {
+                result = mService.connect();
+            } catch (RemoteException e) {
+                Log.e(TAG, e.toString());
+            }
+        } else {
+            Log.w(TAG, "Proxy not attached to service");
+        }
+
+        return result;
+    }
+
+    /**
+     * Disconnects from currently connected host.
+     *
+     * @return
+     */
+    public boolean disconnect() {
+        Log.v(TAG, "disconnect()");
+
+        boolean result = false;
+
+        if (mService != null) {
+            try {
+                result = mService.disconnect();
+            } catch (RemoteException e) {
+                Log.e(TAG, e.toString());
+            }
+        } else {
+            Log.w(TAG, "Proxy not attached to service");
+        }
+
+        return result;
+    }
+}

--- a/core/java/android/bluetooth/BluetoothHidDeviceAppConfiguration.aidl
+++ b/core/java/android/bluetooth/BluetoothHidDeviceAppConfiguration.aidl
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+parcelable BluetoothHidDeviceAppConfiguration;

--- a/core/java/android/bluetooth/BluetoothHidDeviceAppConfiguration.java
+++ b/core/java/android/bluetooth/BluetoothHidDeviceAppConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.util.Random;
+
+/** @hide */
+public final class BluetoothHidDeviceAppConfiguration implements Parcelable {
+    private final long mHash;
+
+    BluetoothHidDeviceAppConfiguration() {
+        Random rnd = new Random();
+        mHash = rnd.nextLong();
+    }
+
+    BluetoothHidDeviceAppConfiguration(long hash) {
+        mHash = hash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof BluetoothHidDeviceAppConfiguration) {
+            BluetoothHidDeviceAppConfiguration config = (BluetoothHidDeviceAppConfiguration) o;
+            return mHash == config.mHash;
+        }
+        return false;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Parcelable.Creator<BluetoothHidDeviceAppConfiguration> CREATOR =
+        new Parcelable.Creator<BluetoothHidDeviceAppConfiguration>() {
+
+        @Override
+        public BluetoothHidDeviceAppConfiguration createFromParcel(Parcel in) {
+            long hash = in.readLong();
+            return new BluetoothHidDeviceAppConfiguration(hash);
+        }
+
+        @Override
+        public BluetoothHidDeviceAppConfiguration[] newArray(int size) {
+            return new BluetoothHidDeviceAppConfiguration[size];
+        }
+    };
+
+    @Override
+    public void writeToParcel(Parcel out, int flags) {
+        out.writeLong(mHash);
+    }
+}

--- a/core/java/android/bluetooth/BluetoothHidDeviceAppQosSettings.aidl
+++ b/core/java/android/bluetooth/BluetoothHidDeviceAppQosSettings.aidl
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+parcelable BluetoothHidDeviceAppQosSettings;

--- a/core/java/android/bluetooth/BluetoothHidDeviceAppQosSettings.java
+++ b/core/java/android/bluetooth/BluetoothHidDeviceAppQosSettings.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.util.Random;
+
+/** @hide */
+public final class BluetoothHidDeviceAppQosSettings implements Parcelable {
+
+    final public int serviceType;
+    final public int tokenRate;
+    final public int tokenBucketSize;
+    final public int peakBandwidth;
+    final public int latency;
+    final public int delayVariation;
+
+    final static public int SERVICE_NO_TRAFFIC = 0x00;
+    final static public int SERVICE_BEST_EFFORT = 0x01;
+    final static public int SERVICE_GUARANTEED = 0x02;
+
+    final static public int MAX = (int) 0xffffffff;
+
+    public BluetoothHidDeviceAppQosSettings(int serviceType, int tokenRate, int tokenBucketSize,
+            int peakBandwidth,
+            int latency, int delayVariation) {
+        this.serviceType = serviceType;
+        this.tokenRate = tokenRate;
+        this.tokenBucketSize = tokenBucketSize;
+        this.peakBandwidth = peakBandwidth;
+        this.latency = latency;
+        this.delayVariation = delayVariation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof BluetoothHidDeviceAppQosSettings) {
+            BluetoothHidDeviceAppQosSettings qos = (BluetoothHidDeviceAppQosSettings) o;
+            return false;
+        }
+        return false;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Parcelable.Creator<BluetoothHidDeviceAppQosSettings> CREATOR =
+        new Parcelable.Creator<BluetoothHidDeviceAppQosSettings>() {
+
+        @Override
+        public BluetoothHidDeviceAppQosSettings createFromParcel(Parcel in) {
+
+            return new BluetoothHidDeviceAppQosSettings(in.readInt(), in.readInt(), in.readInt(),
+                    in.readInt(),
+                    in.readInt(), in.readInt());
+        }
+
+        @Override
+        public BluetoothHidDeviceAppQosSettings[] newArray(int size) {
+            return new BluetoothHidDeviceAppQosSettings[size];
+        }
+    };
+
+    @Override
+    public void writeToParcel(Parcel out, int flags) {
+        out.writeInt(serviceType);
+        out.writeInt(tokenRate);
+        out.writeInt(tokenBucketSize);
+        out.writeInt(peakBandwidth);
+        out.writeInt(latency);
+        out.writeInt(delayVariation);
+    }
+
+    public int[] toArray() {
+        return new int[] {
+                serviceType, tokenRate, tokenBucketSize, peakBandwidth, latency, delayVariation
+        };
+    }
+}

--- a/core/java/android/bluetooth/BluetoothHidDeviceAppSdpSettings.aidl
+++ b/core/java/android/bluetooth/BluetoothHidDeviceAppSdpSettings.aidl
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+parcelable BluetoothHidDeviceAppSdpSettings;

--- a/core/java/android/bluetooth/BluetoothHidDeviceAppSdpSettings.java
+++ b/core/java/android/bluetooth/BluetoothHidDeviceAppSdpSettings.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.util.Random;
+
+/** @hide */
+public final class BluetoothHidDeviceAppSdpSettings implements Parcelable {
+
+    final public String name;
+    final public String description;
+    final public String provider;
+    final public byte subclass;
+    final public byte[] descriptors;
+
+    public BluetoothHidDeviceAppSdpSettings(String name, String description, String provider,
+            byte subclass, byte[] descriptors) {
+        this.name = name;
+        this.description = description;
+        this.provider = provider;
+        this.subclass = subclass;
+        this.descriptors = descriptors.clone();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof BluetoothHidDeviceAppSdpSettings) {
+            BluetoothHidDeviceAppSdpSettings sdp = (BluetoothHidDeviceAppSdpSettings) o;
+            return false;
+        }
+        return false;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Parcelable.Creator<BluetoothHidDeviceAppSdpSettings> CREATOR =
+        new Parcelable.Creator<BluetoothHidDeviceAppSdpSettings>() {
+
+        @Override
+        public BluetoothHidDeviceAppSdpSettings createFromParcel(Parcel in) {
+
+            return new BluetoothHidDeviceAppSdpSettings(in.readString(), in.readString(),
+                    in.readString(), in.readByte(), in.createByteArray());
+        }
+
+        @Override
+        public BluetoothHidDeviceAppSdpSettings[] newArray(int size) {
+            return new BluetoothHidDeviceAppSdpSettings[size];
+        }
+    };
+
+    @Override
+    public void writeToParcel(Parcel out, int flags) {
+        out.writeString(name);
+        out.writeString(description);
+        out.writeString(provider);
+        out.writeByte(subclass);
+        out.writeByteArray(descriptors);
+    }
+}

--- a/core/java/android/bluetooth/BluetoothHidDeviceCallback.java
+++ b/core/java/android/bluetooth/BluetoothHidDeviceCallback.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+import android.util.Log;
+
+/** @hide */
+public abstract class BluetoothHidDeviceCallback {
+
+    private static final String TAG = BluetoothHidDeviceCallback.class.getSimpleName();
+
+    /**
+     * Callback called when application registration state changes. Usually it's
+     * called due to either
+     * {@link BluetoothHidDevice#registerApp(String, String, String, byte, byte[],
+     * BluetoothHidDeviceCallback)}
+     * or
+     * {@link BluetoothHidDevice#unregisterApp(BluetoothHidDeviceAppConfiguration)}
+     * , but can be also unsolicited in case e.g. Bluetooth was turned off in
+     * which case application is unregistered automatically.
+     *
+     * @param pluggedDevice {@link BluetoothDevice} object which represents host
+     *            that currently has Virtual Cable established with device. Only
+     *            valid when application is registered, can be <code>null</code>
+     *            .
+     * @param config {@link BluetoothHidDeviceAppConfiguration} object which
+     *            represents token required to unregister application using
+     *            {@link BluetoothHidDevice#unregisterApp(BluetoothHidDeviceAppConfiguration)}
+     *            .
+     * @param registered <code>true</code> if application is registered,
+     *            <code>false</code> otherwise.
+     */
+    public void onAppStatusChanged(BluetoothDevice pluggedDevice,
+                                    BluetoothHidDeviceAppConfiguration config, boolean registered) {
+        Log.d(TAG, "onAppStatusChanged: pluggedDevice=" + (pluggedDevice == null ?
+            null : pluggedDevice.toString()) + " registered=" + registered);
+    }
+
+    /**
+     * Callback called when connection state with remote host was changed.
+     * Application can assume than Virtual Cable is established when called with
+     * {@link BluetoothProfile#STATE_CONNECTED} <code>state</code>.
+     *
+     * @param device {@link BluetoothDevice} object representing host device
+     *            which connection state was changed.
+     * @param state Connection state as defined in {@link BluetoothProfile}.
+     */
+    public void onConnectionStateChanged(BluetoothDevice device, int state) {
+        Log.d(TAG, "onConnectionStateChanged: device=" + device.toString() + " state=" + state);
+    }
+
+    /**
+     * Callback called when GET_REPORT is received from remote host. Should be
+     * replied by application using
+     * {@link BluetoothHidDevice#replyReport(byte, byte, byte[])}.
+     *
+     * @param type Requested Report Type.
+     * @param id Requested Report Id, can be 0 if no Report Id are defined in
+     *            descriptor.
+     * @param bufferSize Requested buffer size, application shall respond with
+     *            at least given number of bytes.
+     */
+    public void onGetReport(byte type, byte id, int bufferSize) {
+        Log.d(TAG, "onGetReport: type=" + type + " id=" + id + " bufferSize=" + bufferSize);
+    }
+
+    /**
+     * Callback called when SET_REPORT is received from remote host. In case
+     * received data are invalid, application shall respond with
+     * {@link BluetoothHidDevice#reportError()}.
+     *
+     * @param type Report Type.
+     * @param id Report Id.
+     * @param data Report data.
+     */
+    public void onSetReport(byte type, byte id, byte[] data) {
+        Log.d(TAG, "onSetReport: type=" + type + " id=" + id);
+    }
+
+    /**
+     * Callback called when SET_PROTOCOL is received from remote host.
+     * Application shall use this information to send only reports valid for
+     * given protocol mode. By default,
+     * {@link BluetoothHidDevice#PROTOCOL_REPORT_MODE} shall be assumed.
+     *
+     * @param protocol Protocol Mode.
+     */
+    public void onSetProtocol(byte protocol) {
+        Log.d(TAG, "onSetProtocol: protocol=" + protocol);
+    }
+
+    /**
+     * Callback called when report data is received over interrupt channel.
+     * Report Type is assumed to be
+     * {@link BluetoothHidDevice#REPORT_TYPE_OUTPUT}.
+     *
+     * @param reportId Report Id.
+     * @param data Report data.
+     */
+    public void onIntrData(byte reportId, byte[] data) {
+        Log.d(TAG, "onIntrData: reportId=" + reportId);
+    }
+
+    /**
+     * Callback called when Virtual Cable is removed. This can be either due to
+     * {@link BluetoothHidDevice#unplug()} or request from remote side. After
+     * this callback is received connection will be disconnected automatically.
+     */
+    public void onVirtualCableUnplug() {
+        Log.d(TAG, "onVirtualCableUnplug");
+    }
+}

--- a/core/java/android/bluetooth/BluetoothLEServiceUuid.aidl
+++ b/core/java/android/bluetooth/BluetoothLEServiceUuid.aidl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.bluetooth;
+parcelable BluetoothLEServiceUuid;

--- a/core/java/android/bluetooth/BluetoothLEServiceUuid.java
+++ b/core/java/android/bluetooth/BluetoothLEServiceUuid.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.bluetooth;
+
+import java.util.Arrays;
+import java.util.UUID;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+* Bluetooth Low Energy services UUID.
+*/
+/** @hide */
+public final class BluetoothLEServiceUuid implements Parcelable{
+    /** @hide */
+    public final byte type;
+    /** @hide */
+    public final UUID id;
+
+    /* Bluetooth Low Energy Service UUID type */
+    /** @hide */
+    public static final byte BLE_SERVICE_UUID_NONE_TYPE = 0x00;
+    /** @hide */
+    public static final byte BLE_SERVICE_16Bit_UUID_TYPE = 0x03;
+    /** @hide */
+    public static final byte BLE_SERVICE_32Bit_UUID_TYPE = 0x05;
+    /** @hide */
+    public static final byte BLE_SERVICE_128Bit_UUID_TYPE = 0x07;
+    /** @hide */
+    public static final byte BLE_SERVICE_16Bit_SLC_UUID_TYPE = 0x14; /* 16 bit solicitation service uuid */
+    /** @hide */
+    public static final byte BLE_SERVICE_128Bit_SLC_UUID_TYPE = 0x15; /* 128 bit solicitation service uuid */
+
+    /* Bluetoth Low Energy Service UUID value */
+    /** @hide */
+    public static final UUID BLE_SERVICE_EXAMPLE_UUID_VALUE = new UUID(0x0000110F00001000L, 0x800000805F9B34FBL); /* type: 0x15 */
+
+    /** @hide */
+    public BluetoothLEServiceUuid (UUID id)
+    {
+        this.type = BLE_SERVICE_UUID_NONE_TYPE;
+        this.id = id;
+    }
+    /** @hide */
+    public BluetoothLEServiceUuid (byte type, UUID id)
+    {
+        this.type = type;
+        this.id = id;
+    }
+    /** @hide */
+    public byte getType()
+    {
+        return this.type;
+    }
+    /** @hide */
+    public long getLeastSignificantBits()
+    {
+        return id.getLeastSignificantBits();
+    }
+    /** @hide */
+    public long getMostSignificantBits()
+    {
+        return id.getMostSignificantBits();
+    }
+    /** @hide */
+    public int describeContents()
+    {
+        return 0;
+    }
+    /** @hide */
+    public void writeToParcel(Parcel out, int flags)
+    {
+        out.writeByte(this.type);
+        out.writeLong(getLeastSignificantBits());
+        out.writeLong(getMostSignificantBits());
+    }
+    /** @hide */
+    public static final Parcelable.Creator<BluetoothLEServiceUuid> CREATOR =
+               new Parcelable.Creator<BluetoothLEServiceUuid>() {
+        public BluetoothLEServiceUuid createFromParcel(Parcel source) {
+        byte type = source.readByte();
+        long lsb = source.readLong();
+        long msb = source.readLong();
+        return new BluetoothLEServiceUuid(type, new UUID(msb, lsb));
+    }
+    /** @hide */
+    public BluetoothLEServiceUuid[] newArray(int size) {
+        return new BluetoothLEServiceUuid[size];
+    }
+    };
+}

--- a/core/java/android/bluetooth/BluetoothLwPwrProximityMonitor.java
+++ b/core/java/android/bluetooth/BluetoothLwPwrProximityMonitor.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+package android.bluetooth;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.QBluetoothAdapter;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.IBluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
+import android.bluetooth.BluetoothRssiMonitorCallback;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.IBluetoothManager;
+import android.bluetooth.BluetoothManager;
+import android.content.Context;
+import android.os.RemoteException;
+import android.util.Log;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/** @hide */
+public final class  BluetoothLwPwrProximityMonitor implements QBluetoothAdapter.LeLppCallback {
+    private static final     String TAG = "BluetoothLwPwrProximityMonitor";
+    private static final     boolean DBG = true;
+    private BluetoothDevice  mDevice = null;
+    private Context          mContext = null;
+    private BluetoothGatt    mGattProfile = null;
+    private QBluetoothAdapter     mQAdapter = null;
+    private BluetoothRssiMonitorCallback mMonitorCbk;
+    private boolean   mAutoConnect = false;
+    private int       mState;
+    private final Object mStateLock = new Object();
+    /* This timer is triggered in case that BluetoothGatt does not callback when we perform connect/disconnect */
+    private Timer     mTimer = null;
+    private final int mTimeOutValue = 10*1000;
+    private final class ConnectTimeOutTask extends TimerTask {
+        public void run() {
+            if (DBG) Log.d(TAG, "connect timer triggered!");
+            boolean notify = false;
+            synchronized(mStateLock) {
+                if (mState == MONITOR_STATE_STARTING) {
+                    mState = MONITOR_STATE_IDLE;
+                    if (mQAdapter != null && mDevice != null) {
+                        mQAdapter.registerLppClient(BluetoothLwPwrProximityMonitor.this, mDevice.getAddress(), false);
+                    }
+                    notify = true;
+                }
+            }
+            if (notify && mMonitorCbk != null) {
+                mMonitorCbk.onStopped();
+            }
+        }
+    };
+
+    private final class DisconnectTimeOutTask extends TimerTask {
+        public void run() {
+            if (DBG) Log.d(TAG, "disconnect timer triggered");
+            boolean notify = false;
+            synchronized(mStateLock) {
+                if (mState == MONITOR_STATE_STOPPING) {
+                    mState = MONITOR_STATE_IDLE;
+                    if (mQAdapter != null && mDevice != null) {
+                        mQAdapter.registerLppClient(BluetoothLwPwrProximityMonitor.this, mDevice.getAddress(), false);
+                    }
+                    notify = true;
+                }
+            }
+            if (notify && mMonitorCbk != null) {
+                mMonitorCbk.onStopped();
+            }
+        }
+    };
+    /* Monitor state constants */
+    private static final int MONITOR_STATE_IDLE     = 0;
+    private static final int MONITOR_STATE_STARTING = 1;
+    private static final int MONITOR_STATE_STOPPING = 2;
+    private static final int MONITOR_STATE_STARTED  = 3;
+    private static final int MONITOR_STATE_CLOSED   = 4;
+
+    /* constants for rssi threshold event */
+    /** @hide */
+    public static final int RSSI_MONITOR_DISABLED = 0x00;
+    /** @hide */
+    public static final int RSSI_HIGH_ALERT       = 0x01;
+    /** @hide */
+    public static final int RSSI_MILD_ALERT       = 0x02;
+    /** @hide */
+    public static final int RSSI_NO_ALERT         = 0x03;
+
+    /* command status */
+    /** @hide */
+    public static final int COMMAND_STATUS_SUCCESS = 0x00;
+    /** @hide */
+    public static final int COMMAND_STATUS_FAILED  = 0x01;
+    private int mLowerLimit;
+    private int mUpperLimit;
+
+    private final BluetoothGattCallback mGattCallback = new BluetoothGattCallback () {
+        public void onConnectionStateChange (BluetoothGatt gatt, int status,
+                                             int newState) {
+            if (DBG) Log.d(TAG, "onConnectionStateChange() + newState=" + newState);
+            if (mDevice == null) return;
+            if (mGattProfile != gatt) return;
+            if(mQAdapter == null) return;
+            boolean stop = false;
+            synchronized(mStateLock){
+                cancelTimer();
+                if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                    if (mState != MONITOR_STATE_CLOSED) {
+                        mQAdapter.registerLppClient(BluetoothLwPwrProximityMonitor.this,mDevice.getAddress(), false);
+                        mState = MONITOR_STATE_IDLE;
+                        stop = true;
+                    }
+                } else if (newState == BluetoothProfile.STATE_CONNECTED) {
+                    if (mState == MONITOR_STATE_STARTING) {
+                        if (status == BluetoothGatt.GATT_SUCCESS) {
+                            if(!mQAdapter.writeRssiThreshold(BluetoothLwPwrProximityMonitor.this, mLowerLimit, mUpperLimit)) {
+                                mGattProfile.disconnect();
+                                mState = MONITOR_STATE_STOPPING;
+                                setTimer(BluetoothLwPwrProximityMonitor.this.new DisconnectTimeOutTask(), mTimeOutValue);
+                            }
+                        } else {
+                            stop = true;
+                        }
+                    }
+                }
+            }
+            if (stop && mMonitorCbk != null){
+                mMonitorCbk.onStopped();
+                if (DBG) Log.d(TAG, "Monitor is stopped");
+            }
+        }
+    };
+
+    public BluetoothLwPwrProximityMonitor (Context cxt, String device, BluetoothRssiMonitorCallback cbk) {
+        mContext    = cxt;
+        mState      = MONITOR_STATE_CLOSED;
+        mMonitorCbk = cbk;
+
+        try {
+            mDevice     = new BluetoothDevice(device);
+        } catch (IllegalArgumentException e) {
+            mDevice = null;
+            if (DBG) Log.e(TAG, "", e);
+        }
+
+        mQAdapter  = QBluetoothAdapter.getDefaultAdapter();
+        if (mDevice != null && mQAdapter != null) {
+            mState = MONITOR_STATE_IDLE;
+        } else {
+            mDevice = null;
+            mQAdapter = null;
+        }
+    }
+
+    protected void finalize() throws Throwable {
+        try {
+            close();
+        } finally {
+            super.finalize();
+        }
+    }
+
+    private void setTimer(TimerTask task, int delay) {
+        if (DBG) Log.d(TAG, "setTimer() delay=" + delay);
+        mTimer = new Timer();
+        mTimer.schedule(task, delay);
+    }
+
+    private void cancelTimer() {
+        if (DBG) Log.d(TAG, "cancelTimer()");
+        if (mTimer != null) {
+            mTimer.cancel();
+        }
+        mTimer = null;
+    }
+
+    /** @hide */
+    public boolean start (int thresh_min, int thresh_max) {
+        if (DBG) Log.d(TAG, "start() low=" + thresh_min + ", upper=" + thresh_max);
+        synchronized(mStateLock){
+            if (mState != MONITOR_STATE_IDLE) {
+                if (DBG) Log.d(TAG, "start() invalid state, monitor is not idle");
+                return false;
+            }
+            if (!mQAdapter.registerLppClient(this, mDevice.getAddress(), true)) {
+                if (DBG) Log.d(TAG, "cannot register LPP Client");
+                return false;
+            }
+            mState = MONITOR_STATE_STARTING;
+            mLowerLimit = thresh_min;
+            mUpperLimit = thresh_max;
+
+            try {
+                if (mGattProfile == null) {
+                    mGattProfile = mDevice.connectGatt(mContext, mAutoConnect, mGattCallback);
+                    if (mGattProfile == null){
+                        mQAdapter.registerLppClient(this, mDevice.getAddress(), false);
+                        mState = MONITOR_STATE_IDLE;
+                        return false;
+                    }
+                } else {
+                    if (!mGattProfile.connect()) {
+                        mQAdapter.registerLppClient(this, mDevice.getAddress(), false);
+                        mState = MONITOR_STATE_IDLE;
+                        return false;
+                    }
+                }
+            } catch (IllegalStateException e) {
+                mQAdapter.registerLppClient(this, mDevice.getAddress(), false);
+                mState = MONITOR_STATE_IDLE;
+                return false;
+            }
+            setTimer(this.new ConnectTimeOutTask(), mTimeOutValue);
+        }
+        if (DBG) Log.d(TAG, "Monitor is starting");
+        return true;
+    }
+
+    /** @hide */
+    public boolean readRssiThreshold() {
+        if (DBG) Log.d(TAG, "readRssiThreshold()");
+        synchronized(mStateLock) {
+            if (mState == MONITOR_STATE_STARTED) {
+                if (mQAdapter != null) {
+                    mQAdapter.readRssiThreshold(this);
+                    return true;
+                }
+            }
+        }
+        if (DBG) Log.e(TAG, "readRssiThreshold() fail");
+        return false;
+    }
+
+    /** @hide */
+    public void stop() {
+        if (DBG) Log.d(TAG, "stop()");
+        synchronized(mStateLock) {
+            if(mDevice != null && mQAdapter != null && mGattProfile != null &&
+               (mState == MONITOR_STATE_STARTING ||
+                 mState == MONITOR_STATE_STARTED)) {
+                cancelTimer();
+                mQAdapter.enableRssiMonitor(this, false);
+                mGattProfile.disconnect();
+                mState = MONITOR_STATE_STOPPING;
+                setTimer(this.new DisconnectTimeOutTask(), mTimeOutValue);
+                mQAdapter.registerLppClient(this, mDevice.getAddress(), false);
+                if (DBG) Log.d(TAG, "Monitor is stopping");
+            }
+        }
+    }
+    /** @hide */
+    public void close() {
+        if (DBG) Log.d(TAG, "close()");
+        if(MONITOR_STATE_CLOSED == mState)
+            return;
+
+        synchronized(mStateLock) {
+            cancelTimer();
+            if(mDevice != null && mGattProfile != null && mQAdapter != null){
+               if(mState == MONITOR_STATE_STARTING ||
+                 mState == MONITOR_STATE_STARTED) {
+                    if(mState == MONITOR_STATE_STARTED)  mQAdapter.enableRssiMonitor(this, false);
+                    mGattProfile.disconnect();
+                }
+                mGattProfile.close();
+                mQAdapter.registerLppClient(this, mDevice.getAddress(), false);
+            }
+            if (DBG) Log.d(TAG, "Monitor is closed");
+            mState = MONITOR_STATE_CLOSED;
+            mDevice = null;
+            mQAdapter = null;
+            mGattProfile = null;
+            mMonitorCbk = null;
+        }
+    }
+    /** @hide */
+    public void onWriteRssiThreshold(int status) {
+        if (DBG) Log.d(TAG, "onWriteRssiThreshold() status=" + status);
+        synchronized (mStateLock) {
+            if (mState == MONITOR_STATE_STARTING){
+                if (status == BluetoothGatt.GATT_SUCCESS){
+                    if (mQAdapter != null) {
+                        mQAdapter.enableRssiMonitor(this, true);
+                    }
+                } else {
+                    if (mGattProfile != null) {
+                        mGattProfile.disconnect();
+                        mState = MONITOR_STATE_STOPPING;
+                        setTimer(this.new DisconnectTimeOutTask(), mTimeOutValue);
+                    }
+                }
+            }
+        }
+    }
+    /** @hide */
+    public void onReadRssiThreshold(int low, int upper, int alert, int status) {
+        if (DBG) Log.d(TAG, "onReadRssiThreshold() LowerLimit=" + low +
+                       ", UpperLimit=" + upper + ", Alert=" + alert + ", status=" + status);
+        if (mMonitorCbk != null) {
+            mMonitorCbk.onReadRssiThreshold(low, upper, alert, (status == 0)?COMMAND_STATUS_SUCCESS:COMMAND_STATUS_FAILED);
+        }
+    }
+    /** @hide */
+    public void onEnableRssiMonitor(int enable, int status) {
+        if (DBG) Log.d(TAG, "onEnableRssiMonitor() enable=" + enable + ", status=" + status);
+        synchronized(mStateLock) {
+            if (mState == MONITOR_STATE_STARTING) {
+                if (status == BluetoothGatt.GATT_SUCCESS && (enable != 0)) {
+                    mState = MONITOR_STATE_STARTED;
+                    if (DBG) Log.d(TAG, "Monitor is started successfully");
+                } else {
+                    if (mGattProfile != null) {
+                        mGattProfile.disconnect();
+                        mState = MONITOR_STATE_STOPPING;
+                        setTimer(this.new DisconnectTimeOutTask(), mTimeOutValue);
+                    }
+                }
+            }
+        }
+
+        if (mState == MONITOR_STATE_STARTED && mMonitorCbk != null) {
+            if (DBG) Log.d(TAG, "Notify users that monitor has been started successfully");
+            mMonitorCbk.onStarted();
+        }
+    }
+    /** @hide */
+    public void onRssiThresholdEvent(int evtType, int rssi) {
+        if (DBG) Log.d(TAG, "onRssiThresholdEvent() event=" + evtType + ", rssi=" + rssi);
+        if (mMonitorCbk != null) mMonitorCbk.onAlert(evtType, rssi);
+    }
+
+    /** @hide */
+    public boolean onUpdateLease() {
+        if (DBG) Log.d(TAG, "onUpdateLease()");
+        synchronized(mStateLock) {
+            return (mState != MONITOR_STATE_IDLE && mState != MONITOR_STATE_CLOSED);
+        }
+    }
+}

--- a/core/java/android/bluetooth/BluetoothProfile.java
+++ b/core/java/android/bluetooth/BluetoothProfile.java
@@ -124,6 +124,12 @@ public interface BluetoothProfile {
     public static final int DUN = 21;
 
     /**
+     * HID device
+     * @hide
+     */
+    static public final int HID_DEVICE = 22;
+
+    /**
      * Default priority for devices that we try to auto-connect to and
      * and allow incoming connections for the profile
      * @hide

--- a/core/java/android/bluetooth/BluetoothRssiMonitorCallback.java
+++ b/core/java/android/bluetooth/BluetoothRssiMonitorCallback.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.bluetooth;
+
+/** @hide */
+public abstract class BluetoothRssiMonitorCallback {
+    /** @hide */
+    public void onStarted() {
+    }
+
+    /** @hide */
+    public void onStopped() {
+    }
+
+    /** @hide */
+    public void onReadRssiThreshold(int thresh_min, int thresh_max, int alert, int status) {
+    }
+
+    /** @hide */
+    public void onAlert(int evtType, int rssi) {
+    }
+};

--- a/core/java/android/bluetooth/IBluetoothHidDevice.aidl
+++ b/core/java/android/bluetooth/IBluetoothHidDevice.aidl
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothHidDeviceAppConfiguration;
+import android.bluetooth.IBluetoothHidDeviceCallback;
+import android.bluetooth.BluetoothHidDeviceAppSdpSettings;
+import android.bluetooth.BluetoothHidDeviceAppQosSettings;
+
+/** @hide */
+interface IBluetoothHidDevice {
+    boolean registerApp(in BluetoothHidDeviceAppConfiguration config,
+            in BluetoothHidDeviceAppSdpSettings sdp, in BluetoothHidDeviceAppQosSettings inQos,
+            in BluetoothHidDeviceAppQosSettings outQos, in IBluetoothHidDeviceCallback callback);
+    boolean unregisterApp(in BluetoothHidDeviceAppConfiguration config);
+    boolean sendReport(in int id, in byte[] data);
+    boolean replyReport(in byte type, in byte id, in byte[] data);
+    boolean reportError();
+    boolean unplug();
+    boolean connect();
+    boolean disconnect();
+}

--- a/core/java/android/bluetooth/IBluetoothHidDeviceCallback.aidl
+++ b/core/java/android/bluetooth/IBluetoothHidDeviceCallback.aidl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2013 The Linux Foundation. All rights reserved
+ * Not a Contribution.
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothHidDeviceAppConfiguration;
+
+/** @hide */
+interface IBluetoothHidDeviceCallback {
+   void onAppStatusChanged(in BluetoothDevice device, in BluetoothHidDeviceAppConfiguration config, boolean registered);
+   void onConnectionStateChanged(in BluetoothDevice device, in int state);
+   void onGetReport(in byte type, in byte id, in int bufferSize);
+   void onSetReport(in byte type, in byte id, in byte[] data);
+   void onSetProtocol(in byte protocol);
+   void onIntrData(in byte reportId, in byte[] data);
+   void onVirtualCableUnplug();
+}

--- a/core/java/android/bluetooth/IBluetoothManager.aidl
+++ b/core/java/android/bluetooth/IBluetoothManager.aidl
@@ -18,7 +18,9 @@ package android.bluetooth;
 
 import android.bluetooth.IBluetooth;
 import android.bluetooth.IBluetoothGatt;
+import android.bluetooth.IQBluetooth;
 import android.bluetooth.IBluetoothManagerCallback;
+import android.bluetooth.IQBluetoothManagerCallback;
 import android.bluetooth.IBluetoothStateChangeCallback;
 
 /**
@@ -29,7 +31,9 @@ import android.bluetooth.IBluetoothStateChangeCallback;
 interface IBluetoothManager
 {
     IBluetooth registerAdapter(in IBluetoothManagerCallback callback);
+    IQBluetooth registerQAdapter(in IQBluetoothManagerCallback callback);
     void unregisterAdapter(in IBluetoothManagerCallback callback);
+    void unregisterQAdapter(in IQBluetoothManagerCallback callback);
     void registerStateChangeCallback(in IBluetoothStateChangeCallback callback);
     void unregisterStateChangeCallback(in IBluetoothStateChangeCallback callback);
     boolean isEnabled();
@@ -37,6 +41,7 @@ interface IBluetoothManager
     boolean enableNoAutoConnect();
     boolean disable(boolean persist);
     IBluetoothGatt getBluetoothGatt();
+    IQBluetooth getQBluetooth();
 
     String getAddress();
     String getName();

--- a/core/java/android/bluetooth/IQBluetooth.aidl
+++ b/core/java/android/bluetooth/IQBluetooth.aidl
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.bluetooth;
+
+import android.bluetooth.IBluetoothCallback;
+import android.bluetooth.IQBluetoothAdapterCallback;
+import android.bluetooth.BluetoothLEServiceUuid;
+import android.bluetooth.IBluetooth;
+import android.bluetooth.IBluetoothStateChangeCallback;
+import android.bluetooth.BluetoothDevice;
+import android.os.ParcelUuid;
+import android.os.ParcelFileDescriptor;
+
+/**
+ * System private API for talking with the Bluetooth service.
+ *
+ * {@hide}
+ */
+interface IQBluetooth
+{
+    int     startLeScanEx(in BluetoothLEServiceUuid[] services, in IQBluetoothAdapterCallback callback);
+    void    stopLeScanEx(in int token);
+    boolean registerLeLppRssiMonitorClient(in String address, in IQBluetoothAdapterCallback client, in boolean add);
+    void writeLeLppRssiThreshold(in String address, in byte min, in byte max);
+    void readLeLppRssiThreshold(in String address);
+    void enableLeLppRssiMonitor(in String address, in boolean enable);
+}

--- a/core/java/android/bluetooth/IQBluetoothAdapterCallback.aidl
+++ b/core/java/android/bluetooth/IQBluetoothAdapterCallback.aidl
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.bluetooth;
+
+
+
+/**
+ * Callback interface definition for interact with BLE/QAdapterService
+ * @hide
+ */
+
+interface IQBluetoothAdapterCallback {
+    void onScanResult(in String address, in int rssi, in byte[] advData);
+    void onWriteRssiThreshold(in String address, in int status);
+    void onReadRssiThreshold(in String address, in int low, in int upper,
+                             in int alert, in int status);
+    void onEnableRssiMonitor(in String address, in int enable, in int status);
+    void onRssiThresholdEvent(in String address, in int evtType, in int rssi);
+    boolean onUpdateLease();
+}

--- a/core/java/android/bluetooth/IQBluetoothManagerCallback.aidl
+++ b/core/java/android/bluetooth/IQBluetoothManagerCallback.aidl
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.bluetooth;
+
+import android.bluetooth.IQBluetooth;
+
+/**
+ * API for Communication between BluetoothAdapter and BluetoothManager
+ *
+ * {@hide}
+ */
+interface IQBluetoothManagerCallback {
+    void onQBluetoothServiceUp(in IQBluetooth QbluetoothService);
+    void onQBluetoothServiceDown();
+}

--- a/core/java/android/bluetooth/QBluetoothAdapter.java
+++ b/core/java/android/bluetooth/QBluetoothAdapter.java
@@ -1,0 +1,602 @@
+/*
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.bluetooth;
+
+import android.annotation.SdkConstant;
+import android.annotation.SdkConstant.SdkConstantType;
+import android.content.Context;
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.Message;
+import android.os.ParcelUuid;
+import android.os.RemoteException;
+import android.os.ServiceManager;
+import android.bluetooth.BluetoothLEServiceUuid;
+import android.bluetooth.IQBluetoothAdapterCallback;
+import android.util.Log;
+import android.util.Pair;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Represents the local device BLE adapter. The {@link QBluetoothAdapter}
+ * lets you perform fundamental Bluetooth tasks, such as initiate
+ * LE device discovery based on service filters, stop LE scan (with filter)
+ * register and remove LPP clients.
+ *
+ * <p>To get a {@link QBluetoothAdapter} representing this specific Bluetooth
+ * adapter, call the
+ * static {@link #getDefaultAdapter} method; when running on JELLY_BEAN_MR2 and
+ * higher. Once you have the local adapter, you can get a set of
+ * {@link BluetoothDevice} objects representing LE devices found that meet
+ * a specific LE scan filter criterea based on service UUIDs.
+ */
+ /** @hide */
+public final class QBluetoothAdapter {
+    private static final String TAG = "QBluetoothAdapter";
+    private static final boolean DBG = false;
+    private static final boolean VDBG = false;
+
+    private static final String BT_LE_EXTENDED_SCAN_PROP = "ro.qc.bluetooth.le.extendedscan";
+    private boolean mLeExtendedScanFlag = false;
+    private static final int MAX_LE_EXTENDED_SCAN_FILTER_ENTRIES = 0x80;
+
+    private static QBluetoothAdapter sAdapter;
+    private static BluetoothAdapter mAdapter;
+
+    private final IBluetoothManager mManagerService;
+    private IBluetooth mService;
+    private IQBluetooth mQService;
+    private Pair<BluetoothAdapter.LeScanCallback, LEExtendedScanClientWrapper> mLeScanClient = null;
+    private final Object mScanLock = new Object();
+
+    private final Map<LeLppCallback, LeLppClientWrapper> mLppClients = new HashMap<LeLppCallback, LeLppClientWrapper>();
+    /**
+     * Get a handle to the default local QBluetooth adapter.
+     * <p>Currently Android only supports one QBluetooth adapter, but the API
+     * could be extended to support more. This will always return the default
+     * adapter.
+     * @return the default local adapter, or null if Bluetooth is not supported
+     *         on this hardware platform
+     */
+    public static synchronized QBluetoothAdapter getDefaultAdapter() {
+        mAdapter=BluetoothAdapter.getDefaultAdapter();
+        IBluetoothManager managerService=mAdapter.getBluetoothManager();
+        sAdapter = new QBluetoothAdapter(managerService);
+        return sAdapter;
+    }
+
+    /**
+     * Use {@link #getDefaultAdapter} to get the BluetoothAdapter instance.
+     */
+    QBluetoothAdapter(IBluetoothManager managerService){//, IQBluetooth QbluetoothBinder) {
+        if (managerService == null) {
+            throw new IllegalArgumentException("bluetooth manager service is null");
+        }
+        try {
+            //mService = managerService.registerAdapter(mManagerCallback);
+            mService=mAdapter.getBluetoothService(mAdapterServiceCallback);
+           //mQService=managerService.getQBluetooth();
+           mQService=managerService.registerQAdapter(mManagerCallback);
+           Log.i(TAG,"mQService= :" + mQService);
+        } catch (RemoteException e) {Log.e(TAG, "", e);}
+        mManagerService = managerService;
+        /* read property value to check if the bluetooth controller support le extended scan */
+        String value = (String)System.getProperty(BT_LE_EXTENDED_SCAN_PROP);
+        if(value == null){
+            Log.e(TAG, "cannot read property " + BT_LE_EXTENDED_SCAN_PROP);
+        }else {
+            Log.i(TAG, "property " + BT_LE_EXTENDED_SCAN_PROP + "value="+value);
+        }
+
+        /*if(value != null && value.equals("true"))*/{
+            mLeExtendedScanFlag = true;
+        }
+    }
+
+    /**
+     * Starts a scan for Bluetooth LE devices, looking for devices that
+     * advertise given services.It is the most optimal way to filter scan
+     * results.This function can only be invoked if the chipset supports
+     * filtering scan results in controller.Otherwise, it is supposed to
+     * invoke {@link BluetoothAdapter#startLeScan}.Unlike startLeScan,which
+     * filters scan results by ANDing all the services in host, this function
+     * filters scan results by ORed all the services(up to 128 services) in
+     * controller.For this function only one scan session is allowed at the same time,
+     * that means you must make sure there is no scan session in progress before you
+     * invoke this function,and you must terminate this current scan session before
+     * you can initiate a new scan session.
+     *
+     * <p>Devices which advertise any service specified are reported using the
+     * {@link BluetoothAdapter#LeScanCallback#onLeScan} callback.
+     *
+     * <p>Requires {@link android.Manifest.permission#BLUETOOTH_ADMIN} permission.
+     *
+     * @param serviceUuids Array of services used to filter advertising data
+     * @param callback the callback LE scan results are delivered
+     * @return true, if the scan was started successfully
+     *         false,if parameter is bad or chipset doesn't support filtering scan results in controller
+     */
+    public boolean startLeScanEx(BluetoothLEServiceUuid[] serviceUuids, BluetoothAdapter.LeScanCallback callback) {
+        if (VDBG) Log.d(TAG, "startLeScanEx(): " + serviceUuids);
+        if (!mLeExtendedScanFlag) {
+            if (DBG) Log.e(TAG, "startLeScanEx: function is diabled since chipset doesn't support filtering" +
+                                 "scan results in controller, use startLeScan instead");
+            return false;
+        }
+
+        if(callback == null) {
+            if (VDBG) Log.e(TAG, "startLeScanEx: null callback");
+            return false;
+        }
+
+        /* serviceUuuids cannot be empty set  */
+        if ((serviceUuids == null) || (0 == serviceUuids.length) ||
+            (serviceUuids.length > MAX_LE_EXTENDED_SCAN_FILTER_ENTRIES))
+
+        {
+            if (DBG) Log.e(TAG, "startLeScanEx: invalid serviceUuids array");
+            return false;
+        }
+
+        synchronized(mScanLock) {
+            if (mLeScanClient != null) {
+                if (VDBG) Log.e(TAG, "LE Scan in progress");
+                if (mLeScanClient.first == callback)
+                    if (DBG) Log.e(TAG, "duplicate scan request");
+                return false;
+            }
+
+            if (mQService == null) {
+                if (DBG) Log.e(TAG, "QBluetooth Adapter service not supported");
+                return false;
+            }
+
+            LEExtendedScanClientWrapper wrapper = new LEExtendedScanClientWrapper(this, mQService, serviceUuids, callback);
+            if (wrapper != null && wrapper.startScan()) {
+                mLeScanClient = new Pair<BluetoothAdapter.LeScanCallback, LEExtendedScanClientWrapper>(callback, wrapper);
+                if (mLeScanClient == null) {
+                    if (DBG) Log.d(TAG, "no resource");
+                    wrapper.stopScan();
+                    return false;
+                }
+                return true;
+            } else {
+                if (DBG) Log.e(TAG, "LE scan does not start successfully");
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Stops an ongoing Bluetooth LE device scan.
+     *
+     * <p>Requires {@link android.Manifest.permission#BLUETOOTH_ADMIN} permission.
+     *
+     * @param callback used to identify which scan to stop
+     *        must be the same handle used to start the scan
+     */
+    public void stopLeScanEx(BluetoothAdapter.LeScanCallback callback) {
+        synchronized(mScanLock) {
+            if(mLeScanClient != null && mLeScanClient.first == callback) {
+                LEExtendedScanClientWrapper wrapper = mLeScanClient.second;
+                if(wrapper != null) {
+                    wrapper.stopScan();
+                }
+                mLeScanClient = null;
+            }
+        }
+    }
+
+    interface LeLppCallback {
+        public void onWriteRssiThreshold(int status);
+
+        public void onReadRssiThreshold(int low,int upper, int alert, int status);
+
+        public void onEnableRssiMonitor(int enable, int status);
+
+        public void onRssiThresholdEvent(int evtType, int rssi);
+
+        public boolean onUpdateLease();
+    };
+
+    public boolean registerLppClient(LeLppCallback client, String address, boolean add) {
+        synchronized(mLppClients) {
+            if (add) {
+                if(mLppClients.containsKey(client)) {
+                    Log.e(TAG, "Lpp Client has been already registered");
+                    return false;
+                }
+
+                LeLppClientWrapper wrapper = new LeLppClientWrapper(this, mQService, address, client);
+                if(wrapper != null && wrapper.register2(true)) {
+                    mLppClients.put(client, wrapper);
+                    return true;
+                }
+                return false;
+            } else {
+                LeLppClientWrapper wrapper = mLppClients.remove(client);
+                if (wrapper != null) {
+                    wrapper.register2(false);
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+
+   /**
+     * Write the rssi threshold for a connected remote device.
+     *
+     * <p>The {@link BluetoothGattCallback#onWriteRssiThreshold} callback will be
+     * invoked when the write request has been sent.
+     *
+     * <p>Requires {@link android.Manifest.permission#BLUETOOTH} permission.
+     *
+     * @param min    The lower limit of rssi threshold
+     * @param max    The upper limit of rssi threshold
+     * @return true, if the rssi threshold writing request has been sent tsuccessfully
+     */
+    public boolean writeRssiThreshold(LeLppCallback client, int min, int max) {
+        LeLppClientWrapper wrapper = null;
+        synchronized(mLppClients) {
+            wrapper = mLppClients.get(client);
+        }
+        if (wrapper == null) return false;
+
+        wrapper.writeRssiThreshold((byte)min, (byte)max);
+        return true;
+    }
+
+    /**
+     * Enable rssi monitoring for a connected remote device.
+     *
+     * <p>The {@link BluetoothGattCallback#onEnableRssiMonitor} callback will be
+     * invoked when the rssi monitor enable/disable request has been sent.
+     *
+     * <p>Requires {@link android.Manifest.permission#BLUETOOTH} permission.
+     *
+     * @param enable disable/enable rssi monitor
+     * @return true, if the rssi monitoring request has been sent tsuccessfully
+     */
+    public boolean enableRssiMonitor(LeLppCallback client, boolean enable){
+        LeLppClientWrapper wrapper = null;
+        synchronized(mLppClients) {
+            wrapper = mLppClients.get(client);
+        }
+        if (wrapper == null) return false;
+
+        wrapper.enableMonitor(enable);
+        return true;
+    }
+
+   /**
+     * Read the rssi threshold for a connected remote device.
+     *
+     * <p>The {@link BluetoothGattCallback#onReadRssiThreshold} callback will be
+     * invoked when the rssi threshold has been read.
+     *
+     * <p>Requires {@link android.Manifest.permission#BLUETOOTH} permission.
+     *
+     * @return true, if the rssi threshold has been requested successfully
+     */
+    public boolean readRssiThreshold(LeLppCallback client) {
+        LeLppClientWrapper wrapper = null;
+        synchronized(mLppClients) {
+            wrapper = mLppClients.get(client);
+        }
+        if (wrapper == null) return false;
+
+        wrapper.readRssiThreshold();
+        return true;
+    }
+
+    protected void finalize() throws Throwable {
+        try {
+            mManagerService.unregisterQAdapter(mManagerCallback);
+        } catch (RemoteException e) {
+            Log.e(TAG, "", e);
+        } finally {
+            super.finalize();
+        }
+    }
+
+    private static class LEExtendedScanClientWrapper extends IQBluetoothAdapterCallback.Stub {
+        private final WeakReference<QBluetoothAdapter> mAdapter;
+        private final IQBluetooth mQBluetoothAdapterService;
+        private final BluetoothLEServiceUuid[] mServiceFilter;
+        private final BluetoothAdapter.LeScanCallback mClient;
+        private int mScanToken;
+
+        public LEExtendedScanClientWrapper (QBluetoothAdapter adapter, IQBluetooth adapterService,
+                                                BluetoothLEServiceUuid[] services, BluetoothAdapter.LeScanCallback callback) {
+            this.mAdapter = new WeakReference<QBluetoothAdapter> (adapter);
+            this.mQBluetoothAdapterService = adapterService;
+            this.mServiceFilter = services;
+            this.mClient = callback;
+            this.mScanToken = -1;
+        }
+
+        public boolean startScan() {
+            boolean started = false;
+            synchronized(this) {
+                if(mScanToken == -1 &&
+                mQBluetoothAdapterService != null) {
+                    try {
+                        mScanToken =  mQBluetoothAdapterService.startLeScanEx(mServiceFilter, this);
+                        if(mScanToken != -1) {
+                            started = true;
+                        }
+                    } catch (RemoteException e) {
+                        Log.e(TAG, "", e);
+                        started = false;
+                    }
+                }
+            }
+            return started;
+        }
+
+        public void stopScan() {
+            synchronized(this) {
+                if(mScanToken != -1 &&
+                    mQBluetoothAdapterService != null) {
+                    try {
+                        mQBluetoothAdapterService.stopLeScanEx(mScanToken);
+                    } catch (RemoteException e) {
+                        Log.e(TAG, "", e);
+                    }
+                    mScanToken = -1;
+                }
+            }
+        }
+        /**
+         * Callback reporting LE extended scan result.
+         * @hide
+         */
+        public void onScanResult(String address, int rssi, byte[] advData) {
+            synchronized(this) {
+                if(mScanToken <= 0) return;
+            }
+            try {
+                QBluetoothAdapter adapter = mAdapter.get();
+                if(adapter == null){
+                    Log.e(TAG, "OnScanResult, QBluetoothAdapter null");
+                    return;
+                }
+                mClient.onLeScan(BluetoothAdapter.getDefaultAdapter().getRemoteDevice(address), rssi, advData);
+            } catch (Exception e) {
+                Log.w(TAG, "Unhandled exception: " + e);
+            }
+        }
+
+        public void onWriteRssiThreshold(String address, int status) {
+        }
+
+        public void onReadRssiThreshold(String address, int low, int upper,
+                                        int alert, int status) {
+        }
+
+        public void onEnableRssiMonitor(String address, int enable, int status) {
+        }
+
+        public void onRssiThresholdEvent(String address, int evtType, int rssi) {
+        }
+
+        public boolean onUpdateLease() {
+            QBluetoothAdapter adapter = mAdapter.get();
+            if(adapter == null){
+                Log.e(TAG, "onUpdateLease(), QBluetoothAdapter null");
+                return false;
+            }
+            return true;
+        }
+    }
+
+    private static class LeLppClientWrapper extends IQBluetoothAdapterCallback.Stub {
+            private final WeakReference<QBluetoothAdapter> mAdapter;
+            private final IQBluetooth mQBluetoothAdapterService;
+            private final String mDevice;
+            private final LeLppCallback client;
+
+            public LeLppClientWrapper (QBluetoothAdapter adapter, IQBluetooth adapterService,
+                                       String address, LeLppCallback callback) {
+                this.mAdapter = new WeakReference<QBluetoothAdapter> (adapter);
+                this.mQBluetoothAdapterService = adapterService;
+                this.mDevice = address;
+                this.client = callback;
+            }
+
+            public boolean register2(boolean add) {
+                if(mQBluetoothAdapterService != null) {
+                    try {
+                        return mQBluetoothAdapterService.registerLeLppRssiMonitorClient(mDevice, this, add);
+                    } catch (RemoteException e) {
+                        Log.w(TAG, "", e);
+                    }
+                }
+                return false;
+            }
+
+            public void writeRssiThreshold(byte min, byte max) {
+                if(mQBluetoothAdapterService != null) {
+                    try {
+                        mQBluetoothAdapterService.writeLeLppRssiThreshold(mDevice, min, max);
+                    } catch (RemoteException e) {
+                        Log.w(TAG, "", e);
+                    }
+                }
+            }
+
+            public void enableMonitor(boolean enable) {
+                if(mQBluetoothAdapterService != null) {
+                    try {
+                        mQBluetoothAdapterService.enableLeLppRssiMonitor(mDevice, enable);
+                    } catch (RemoteException e) {
+                        Log.w(TAG, "", e);
+                    }
+                }
+            }
+
+            public void readRssiThreshold() {
+                if(mQBluetoothAdapterService != null) {
+                    try {
+                        mQBluetoothAdapterService.readLeLppRssiThreshold(mDevice);
+                    } catch (RemoteException e) {
+                        Log.w(TAG, "", e);
+                    }
+                }
+            }
+
+            public void onScanResult(String address, int rssi, byte[] advData) {
+            }
+
+           /**
+             * Rssi threshold has been written
+             * @hide
+             */
+            public void onWriteRssiThreshold(String address, int status){
+                if (client == null) {
+                    return;
+                }
+                try {
+                    client.onWriteRssiThreshold(status);
+                } catch (Exception ex) {
+                    Log.w(TAG, "Unhandled exception: " + ex);
+                }
+            }
+
+            /**
+             * RSSI threshold has been read
+             * @hide
+             */
+            public void onReadRssiThreshold(String address, int low, int upper,
+                                            int alert, int status){
+                if (client == null) {
+                    return;
+                }
+                try {
+                    client.onReadRssiThreshold(low, upper, alert, status);
+                } catch (Exception ex) {
+                    Log.w(TAG, "Unhandled exception: " + ex);
+                }
+            }
+
+           /**
+             * Remote Device RSSI monitoring has been enabled/disabled
+             * @hide
+             */
+            public void onEnableRssiMonitor(String address, int enable, int status){
+                if (client == null) {
+                    return;
+                }
+                try {
+                    client.onEnableRssiMonitor(enable, status);
+                } catch (Exception ex) {
+                    Log.w(TAG, "Unhandled exception: " + ex);
+                }
+            }
+
+            /**
+             * RSSI threshold event reported
+             * @hide
+             */
+            public void onRssiThresholdEvent(String address, int evtType, int rssi){
+                if (client == null) {
+                    return;
+                }
+                try {
+                    client.onRssiThresholdEvent(evtType, rssi);
+                } catch (Exception ex) {
+                    Log.w(TAG, "Unhandled exception: " + ex);
+                }
+            }
+
+            public boolean onUpdateLease() {
+                if (client == null) return false;
+                try {
+                    return client.onUpdateLease();
+                } catch (Exception ex) {
+                    Log.w(TAG, "Unhandled exception: " + ex);
+                    return false;
+                }
+            }
+    }
+
+    final private IBluetoothManagerCallback mAdapterServiceCallback =
+        new IBluetoothManagerCallback.Stub() {
+            public void onBluetoothServiceUp(IBluetooth bluetoothService) {
+                synchronized (mAdapterServiceCallback) {
+                    //initialize the global params again
+                    mService = bluetoothService;
+                    Log.i(TAG,"onBluetoothServiceUp Adapter ON: mService: "+ mService + " mQService: " + mQService+ " ManagerService:" + mManagerService);
+                }
+            }
+
+            public void onBluetoothServiceDown() {
+                synchronized (mAdapterServiceCallback) {
+                    mService = null;
+                    Log.i(TAG,"onBluetoothServiceDown Adapter OFF: mService: "+ mService + " mQService: " + mQService);
+                }
+            }
+    };
+
+
+    final private IQBluetoothManagerCallback mManagerCallback =
+        new IQBluetoothManagerCallback.Stub() {
+            public void onQBluetoothServiceUp(IQBluetooth qcbluetoothService) {
+                if (VDBG) Log.i(TAG, "on QBluetoothServiceUp: " + qcbluetoothService);
+                synchronized (mManagerCallback) {
+                    //initialize the global params again
+                    mQService = qcbluetoothService;
+                    Log.i(TAG,"onQBluetoothServiceUp: Adapter ON: mService: "+ mService + " mQService: " + mQService+ " ManagerService:" + mManagerService);
+                }
+            }
+
+            public void onQBluetoothServiceDown() {
+                if (VDBG) Log.i(TAG, "onQBluetoothServiceDown: " + mService);
+                synchronized (mManagerCallback) {
+                    mQService=null;
+                    Log.i(TAG,"onQBluetoothServiceDown: Adapter OFF: mService: "+ mService + " mQService: " + mQService);
+                }
+            }
+    };
+
+}

--- a/obex/javax/obex/ClientSession.java
+++ b/obex/javax/obex/ClientSession.java
@@ -59,6 +59,8 @@ public final class ClientSession extends ObexSession {
 
     private boolean mRequestActive;
 
+    private boolean setMTU = false;
+
     private final InputStream mInput;
 
     private final OutputStream mOutput;
@@ -243,6 +245,10 @@ public final class ClientSession extends ObexSession {
             return -1;
         }
         return ObexHelper.convertToLong(mConnectionId);
+    }
+
+    public void reduceMTU(boolean enable) {
+        setMTU = enable;
     }
 
     public Operation put(HeaderSet header) throws IOException {
@@ -451,7 +457,9 @@ public final class ClientSession extends ObexSession {
                 maxPacketSize = (mInput.read() << 8) + mInput.read();
 
                 //check with local max size
-                if (maxPacketSize > ObexHelper.MAX_CLIENT_PACKET_SIZE) {
+                if (setMTU) {
+                    maxPacketSize = ObexHelper.A2DP_SCO_OBEX_MAX_CLIENT_PACKET_SIZE;
+                } else if (maxPacketSize > ObexHelper.MAX_CLIENT_PACKET_SIZE) {
                     maxPacketSize = ObexHelper.MAX_CLIENT_PACKET_SIZE;
                 }
 

--- a/obex/javax/obex/ObexHelper.java
+++ b/obex/javax/obex/ObexHelper.java
@@ -77,6 +77,7 @@ public final class ObexHelper {
      * TODO: Should be removed as soon as Microsoft updates their driver.
      */
     public static final int MAX_CLIENT_PACKET_SIZE = 0xFC00;
+    public static final int A2DP_SCO_OBEX_MAX_CLIENT_PACKET_SIZE = 0x2000;
 
     public static final int OBEX_OPCODE_CONNECT = 0x80;
 

--- a/services/java/com/android/server/BluetoothManagerService.java
+++ b/services/java/com/android/server/BluetoothManagerService.java
@@ -19,10 +19,12 @@ package com.android.server;
 import android.app.ActivityManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.IBluetooth;
+import android.bluetooth.IQBluetooth;
 import android.bluetooth.IBluetoothGatt;
 import android.bluetooth.IBluetoothCallback;
 import android.bluetooth.IBluetoothManager;
 import android.bluetooth.IBluetoothManagerCallback;
+import android.bluetooth.IQBluetoothManagerCallback;
 import android.bluetooth.IBluetoothStateChangeCallback;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -68,6 +70,8 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
     private static final int MESSAGE_DISABLE = 2;
     private static final int MESSAGE_REGISTER_ADAPTER = 20;
     private static final int MESSAGE_UNREGISTER_ADAPTER = 21;
+    private static final int MESSAGE_REGISTER_Q_ADAPTER = 22;
+    private static final int MESSAGE_UNREGISTER_Q_ADAPTER = 23;
     private static final int MESSAGE_REGISTER_STATE_CHANGE_CALLBACK = 30;
     private static final int MESSAGE_UNREGISTER_STATE_CHANGE_CALLBACK = 31;
     private static final int MESSAGE_BLUETOOTH_SERVICE_CONNECTED = 40;
@@ -94,6 +98,7 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
 
     private static final int SERVICE_IBLUETOOTH = 1;
     private static final int SERVICE_IBLUETOOTHGATT = 2;
+    private static final int SERVICE_IBLUETOOTHQ = 3;
 
     private final Context mContext;
 
@@ -103,8 +108,10 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
     private String mName;
     private final ContentResolver mContentResolver;
     private final RemoteCallbackList<IBluetoothManagerCallback> mCallbacks;
+    private final RemoteCallbackList<IQBluetoothManagerCallback> mQCallbacks;
     private final RemoteCallbackList<IBluetoothStateChangeCallback> mStateChangeCallbacks;
     private IBluetooth mBluetooth;
+    private IQBluetooth mQBluetooth;
     private IBluetoothGatt mBluetoothGatt;
     private boolean mBinding;
     private boolean mUnbinding;
@@ -197,6 +204,7 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
 
         mContext = context;
         mBluetooth = null;
+        mQBluetooth = null;
         mBinding = false;
         mUnbinding = false;
         mEnable = false;
@@ -208,6 +216,7 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
         mErrorRecoveryRetryCounter = 0;
         mContentResolver = context.getContentResolver();
         mCallbacks = new RemoteCallbackList<IBluetoothManagerCallback>();
+        mQCallbacks = new RemoteCallbackList<IQBluetoothManagerCallback>();
         mStateChangeCallbacks = new RemoteCallbackList<IBluetoothStateChangeCallback>();
         IntentFilter filter = new IntentFilter(Intent.ACTION_BOOT_COMPLETED);
         filter.addAction(BluetoothAdapter.ACTION_LOCAL_NAME_CHANGED);
@@ -316,10 +325,27 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
         }
     }
 
+    public IQBluetooth registerQAdapter(IQBluetoothManagerCallback callback){
+        Message msg = mHandler.obtainMessage(MESSAGE_REGISTER_Q_ADAPTER);
+        msg.obj = callback;
+        mHandler.sendMessage(msg);
+        synchronized(mConnection) {
+            return mQBluetooth;
+        }
+    }
+
     public void unregisterAdapter(IBluetoothManagerCallback callback) {
         mContext.enforceCallingOrSelfPermission(BLUETOOTH_PERM,
                                                 "Need BLUETOOTH permission");
         Message msg = mHandler.obtainMessage(MESSAGE_UNREGISTER_ADAPTER);
+        msg.obj = callback;
+        mHandler.sendMessage(msg);
+    }
+
+    public void unregisterQAdapter(IQBluetoothManagerCallback callback) {
+        mContext.enforceCallingOrSelfPermission(BLUETOOTH_PERM,
+                                                "Need BLUETOOTH permission");
+        Message msg = mHandler.obtainMessage(MESSAGE_UNREGISTER_Q_ADAPTER);
         msg.obj = callback;
         mHandler.sendMessage(msg);
     }
@@ -468,6 +494,7 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
                 }
                 if (DBG) Log.d(TAG, "Sending unbind request.");
                 mBluetooth = null;
+                mQBluetooth = null;
                 //Unbind
                 mContext.unbindService(mConnection);
                 mUnbinding = false;
@@ -481,6 +508,11 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
     public IBluetoothGatt getBluetoothGatt() {
         // sync protection
         return mBluetoothGatt;
+    }
+
+    public IQBluetooth getQBluetooth() {
+        // sync protection
+        return mQBluetooth;
     }
 
     private void sendBluetoothStateCallback(boolean isUp) {
@@ -531,6 +563,39 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
             }
             mCallbacks.finishBroadcast();
         }
+    }
+
+    /**
+     * Inform QBluetoothAdapter instances that QAdapter service is up
+     */
+    private void sendQBluetoothServiceUpCallback() {
+        if (DBG) Log.d(TAG,"Calling onQBluetoothServiceUp callbacks");
+        int n = mQCallbacks.beginBroadcast();
+        Log.d(TAG,"Broadcasting onQBluetoothServiceUp() to " + n + " receivers.");
+        for (int i=0; i <n;i++) {
+            try {
+                mQCallbacks.getBroadcastItem(i).onQBluetoothServiceUp(mQBluetooth);
+            }  catch (RemoteException e) {
+                Log.e(TAG, "Unable to call onQBluetoothServiceUp() on callback #" + i, e);
+            }
+        }
+        mQCallbacks.finishBroadcast();
+    }
+    /**
+     * Inform BluetoothAdapter instances that Adapter service is down
+     */
+    private void sendQBluetoothServiceDownCallback() {
+        if (DBG) Log.d(TAG,"Calling onQBluetoothServiceDown callbacks");
+        int n = mQCallbacks.beginBroadcast();
+        Log.d(TAG,"Broadcasting onQBluetoothServiceDown() to " + n + " receivers.");
+        for (int i=0; i <n;i++) {
+            try {
+                mQCallbacks.getBroadcastItem(i).onQBluetoothServiceDown();
+            }  catch (RemoteException e) {
+                Log.e(TAG, "Unable to call onQBluetoothServiceDown() on callback #" + i, e);
+            }
+        }
+            mQCallbacks.finishBroadcast();
     }
     public String getAddress() {
         mContext.enforceCallingOrSelfPermission(BLUETOOTH_PERM,
@@ -603,6 +668,10 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
                 // } else if (className.getClassName().equals(IBluetoothGatt.class.getName())) {
             } else if (className.getClassName().equals("com.android.bluetooth.gatt.GattService")) {
                 msg.arg1 = SERVICE_IBLUETOOTHGATT;
+                // } else if (className.getClassName().equals(IBluetoothGatt.class.getName())) {
+            } else if (className.getClassName().equals("com.android.bluetooth.btservice.QAdapterService")) {
+                msg.arg1 = SERVICE_IBLUETOOTHQ;
+                Log.e(TAG, "Bluetooth Q service connected: " + className.getClassName());
             } else {
                 Log.e(TAG, "Unknown service connected: " + className.getClassName());
                 return;
@@ -620,6 +689,8 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
                 msg.arg1 = SERVICE_IBLUETOOTH;
             } else if (className.getClassName().equals("com.android.bluetooth.gatt.GattService")) {
                 msg.arg1 = SERVICE_IBLUETOOTHGATT;
+            } else if (className.getClassName().equals("com.android.bluetooth.btservice.QAdapterService")) {
+                msg.arg1 = SERVICE_IBLUETOOTHQ;
             } else {
                 Log.e(TAG, "Unknown service disconnected: " + className.getClassName());
                 return;
@@ -763,11 +834,26 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
                     Log.d(TAG,"Added callback: " +  (callback == null? "null": callback)  +":" +added );
                 }
                     break;
+
+                case MESSAGE_REGISTER_Q_ADAPTER:
+                {
+                    IQBluetoothManagerCallback callback = (IQBluetoothManagerCallback) msg.obj;
+                    boolean added = mQCallbacks.register(callback);
+                    Log.d(TAG,"Q Added callback: " +  (callback == null? "null": callback)  +":" +added );
+                }
+                    break;
                 case MESSAGE_UNREGISTER_ADAPTER:
                 {
                     IBluetoothManagerCallback callback = (IBluetoothManagerCallback) msg.obj;
                     boolean removed = mCallbacks.unregister(callback);
                     Log.d(TAG,"Removed callback: " +  (callback == null? "null": callback)  +":" + removed);
+                    break;
+                }
+                case MESSAGE_UNREGISTER_Q_ADAPTER:
+                {
+                    IQBluetoothManagerCallback callback = (IQBluetoothManagerCallback) msg.obj;
+                    boolean removed = mQCallbacks.unregister(callback);
+                    Log.d(TAG,"Q Removed callback: " +  (callback == null? "null": callback)  +":" + removed);
                     break;
                 }
                 case MESSAGE_REGISTER_STATE_CHANGE_CALLBACK:
@@ -798,6 +884,13 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
                             mBluetoothGatt = IBluetoothGatt.Stub.asInterface(service);
                             break;
                         } // else must be SERVICE_IBLUETOOTH
+
+                        if (msg.arg1 == SERVICE_IBLUETOOTHQ) {
+                            mQBluetooth = IQBluetooth.Stub.asInterface(service);
+                            Log.d(TAG,"mQBluetooth: " + mQBluetooth);
+                            sendQBluetoothServiceUpCallback();
+                            break;
+                        }
 
                         //Remove timeout
                         mHandler.removeMessages(MESSAGE_TIMEOUT_BIND);
@@ -901,6 +994,9 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
                         } else if (msg.arg1 == SERVICE_IBLUETOOTHGATT) {
                             mBluetoothGatt = null;
                             break;
+                        } else if (msg.arg1 == SERVICE_IBLUETOOTHQ) {
+                            mQBluetooth = null;
+                            break;
                         } else {
                             Log.e(TAG, "Bad msg.arg1: " + msg.arg1);
                             break;
@@ -919,6 +1015,8 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
 
                     if (!mConnection.isGetNameAddressOnly()) {
                         sendBluetoothServiceDownCallback();
+
+                        sendQBluetoothServiceDownCallback();
 
                         // Send BT state broadcast to update
                         // the BT icon correctly
@@ -1005,6 +1103,7 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
                         bluetoothStateChangeHandler(BluetoothAdapter.STATE_TURNING_OFF,
                                                     BluetoothAdapter.STATE_OFF);
                         sendBluetoothServiceDownCallback();
+                        sendQBluetoothServiceDownCallback();
                         synchronized (mConnection) {
                             if (mBluetooth != null) {
                                 mBluetooth = null;
@@ -1144,14 +1243,18 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
                 if (isUp) {
                     // connect to GattService
                     if (mContext.getPackageManager().hasSystemFeature(
-                                                     PackageManager.FEATURE_BLUETOOTH_LE)) {
+                                                        PackageManager.FEATURE_BLUETOOTH_LE)) {
                         Intent i = new Intent(IBluetoothGatt.class.getName());
                         doBind(i, mConnection, Context.BIND_AUTO_CREATE, UserHandle.CURRENT);
+
+                        Intent iqc = new Intent(IQBluetooth.class.getName());
+                        doBind(iqc, mConnection, Context.BIND_AUTO_CREATE, UserHandle.CURRENT);
                     }
                 } else {
                     //If Bluetooth is off, send service down event to proxy objects, and unbind
                     if (!isUp && canUnbindBluetoothService()) {
                         sendBluetoothServiceDownCallback();
+                        sendQBluetoothServiceDownCallback();
                         unbindAndFinish();
                     }
                 }
@@ -1250,9 +1353,12 @@ class BluetoothManagerService extends IBluetoothManager.Stub {
         waitForOnOff(false, true);
 
         sendBluetoothServiceDownCallback();
+        sendQBluetoothServiceDownCallback();
         synchronized (mConnection) {
             if (mBluetooth != null) {
                 mBluetooth = null;
+                if(mQBluetooth!=null)
+                    mQBluetooth=null;
                 //Unbind
                 mContext.unbindService(mConnection);
             }

--- a/telephony/java/com/android/internal/telephony/DctConstants.java
+++ b/telephony/java/com/android/internal/telephony/DctConstants.java
@@ -97,6 +97,7 @@ public class DctConstants {
     public static final int CMD_ENABLE_MOBILE_PROVISIONING = BASE + 37;
     public static final int CMD_IS_PROVISIONING_APN = BASE + 38;
     public static final int EVENT_PROVISIONING_APN_ALARM = BASE + 39;
+    public static final int EVENT_DATA_RAT_CHANGED = BASE + 40;
 
     /***** Constants *****/
 


### PR DESCRIPTION
Bluetooth: Changes for LPP and extended LE scan

This patch includes implementation of a new Bluetooth
Adapter named QBluetoothAdapter for implementing LE
specific tasks that the default adapter doesnt perform.
This patch also implements Low power proximity and extended
LE scan functionality based on service UUIDs.

CRs-Fixed: 581289
Change-Id: I63e0593f79c8929d4e18cee0472fcb401c8892e7

Bluetooth: HID: Add support for HID Device Role

This patch adds the HID Device Role support in Bluetooth framework.
Also AIDL and callback related files for HID Device role are added
to provide interface for third party applications to communicate with
HID device Service.

Change-Id: Id03a362b7bcfa2e76056fa0197eaac12ce49b5a2
CRs-Fixed: 573086

Telephony: Add data rat constant

Change-Id: Ie722dc8fc6b31205230903483c0bc196ecc1b82b

OBEX: Reduce Obex MTU size for A2DP or SCO concurrency

Reduce Obex MTU to 8k from 64k when OPP send is tried with
SCO / A2DP streaming in progress, so that the continue
response for first complete Obex PUT packet is received
from SOC within 50 seconds time frame.

CRs-Fixed: 571865
Change-Id: I1eae114f57f2a92ee4b26c82d8f55fafe02775b8
