### PR TITLE
Frameworks: Fix hw menu key from unlocking on swipe

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -4489,7 +4489,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     }
 
     public boolean onMenuPressed() {
-        return mState == StatusBarState.KEYGUARD && mStatusBarKeyguardViewManager.onMenuPressed();
+       return mState == StatusBarState.KEYGUARD && mStatusBarKeyguardViewManager.isSecure();
     }
 
     public void endAffordanceLaunch() {


### PR DESCRIPTION
this fixes the menu capacitive key unlocking the swipe lockscreen when pressed.
thanks to @InkSlinger66
