### PR TITLE
Smart Pulldown [1/2] (code works as expected; conducted extensive tests on my device)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -3002,6 +3002,12 @@ public final class Settings {
         */
         public static final String DEV_FORCE_SHOW_NAVBAR = "dev_force_show_navbar";
 
+        /**
+         * Quick Settings Smart Pulldown
+         *
+         * @hide
+         */
+        public static final String QS_SMART_PULLDOWN = "qs_smart_pulldown";
 
         /**
          * Date format string

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NotificationData.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NotificationData.java
@@ -283,6 +283,18 @@ public class NotificationData {
     }
 
     /**
+     * Return whether there are any visible notifications (i.e. without an error).
+     */
+    public boolean hasActiveVisibleNotifications() {
+        for (Entry e : mSortedAndFiltered) {
+            if (e.getContentView() != null) { // the view successfully inflated
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Return whether there are any clearable notifications (that aren't errors).
      */
     public boolean hasActiveClearableNotifications() {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -2038,6 +2038,21 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         mNotificationPanel.notifyVisibleChildrenChanged();
     }
 
+    protected boolean hasActiveVisibleNotifications() {
+        Log.d(TAG, "hasActiveVisibleNotifications: " +
+                    mNotificationData.hasActiveVisibleNotifications());
+        return mNotificationData.hasActiveVisibleNotifications();
+    }
+
+    protected boolean hasActiveClearableNotifications() {
+        final boolean clearable = hasActiveNotifications() &&
+                    mNotificationData.hasActiveClearableNotifications();
+        Log.d(TAG, "hasActiveClearableNotifications: N=" +
+                    mNotificationData.getActiveNotifications().size() + " any=" +
+                    hasActiveNotifications() + " clearable=" + clearable);
+        return clearable;
+    }
+
     @Override
     protected void setAreThereNotifications() {
 


### PR DESCRIPTION
Adds the ability to directly open the QS panel when there are
no notifications present in the notification panel.
This commit combines the enhancement by HardCorePawn for detectin
notification types for the same.

Credits: kufikugel, HardCorePawn

PS 2-4 : Cleanup

Adapted to LP

Added Jubakubas commit

SystemUI: Smart Pull-Down - Any Notification (1/2)

PS
- fixed logic to go inline with all mode in settings - should be fixed on kk as well

Adapted to M by spezi77

Change-Id: I6179c2000399c2b9371ea389eacc7566a499ce34
Signed-off-by: spezi77 spezi77@gmx.com
